### PR TITLE
Fire loadend after load on final XHR state change

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -131,6 +131,7 @@ createXHRFacade = (xhr) ->
         faceEvents.fire "readystatechange"
         if currentState is 4
           faceEvents.fire "load"
+          faceEvents.fire "loadend"
       return
 
 


### PR DESCRIPTION
This supports frameworks/users relying on loadend progress event (e.g., [sproutcore 1.9.2](https://github.com/sproutcore/sproutcore/blob/REL-1.9.2/frameworks/ajax/system/response.js#L551)).

The loadend event can be referenced on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest?redirectlocale=en-US&redirectslug=DOM%2FXMLHttpRequest%2FUsing_XMLHttpRequest#Monitoring_progress).
