### PR TITLE
wrapping fake event making logic with a catch

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -152,7 +152,10 @@ window.XMLHttpRequest = ->
       msieEventObject.type = type
       msieEventObject
     else
-      new Event(type)
+      # on some platforms like android 4.1.2 and safari on windows, it appears
+      # that new Event is not allowed
+      try new Event(type)
+      catch e then {type: type}
 
   checkEvent = (e) ->
     clone = {}


### PR DESCRIPTION
the ultimate goal is to produce the most convincing event-like object available on the platform. it is known on android 4.1.2 and safari on windows that Event cannot be used as a constructor, and this is a sort of next best option for those platforms.

should fix #5

I tested this on Browserstack with Safari (where new Event was likewise failing) and it worked fine.
