### PR TITLE
Fix readyBody.response for latest AngularJs

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -89,7 +89,7 @@ window.XMLHttpRequest = ->
 
   readyBody = ->
     facade.responseType = response.type or ''
-    facade.response = response.data or null
+    facade.response = response.data or or response.text or null
     facade.responseText = response.text or response.data or ''
     facade.responseXML = response.xml or null
     return


### PR DESCRIPTION
A recent change in AngularJs broke xHook and xdomain resulting in an empty response
see [angular file changes](https://github.com/angular/angular.js/commit/a9cccbe14f1bd9048f5dab4443f58c804d4259a1#diff-fc6d3d48fd6597bd97d30eab9497841bR90)
