### PR TITLE
AngularJS expects response object to be filled

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -208,9 +208,10 @@ XHookHttpRequest = window[XMLHTTP] = ->
   writeBody = ->
     if response.hasOwnProperty 'text'
       facade.responseText = response.text
-    if response.hasOwnProperty 'xml'
+    else if response.hasOwnProperty 'xml'
       facade.responseXML = response.xml
-    facade.response = response.data or null
+    else
+      facade.response = response.data or null
     return
 
   #ensure ready state 0 through 4 is handled


### PR DESCRIPTION
Only fill the response object if responseXML and responseText are not found.

Angular JS fails to fetch new views from CORS request because it expects response to be filled:
https://github.com/angular/angular.js/blob/d3b1f502e3099d91042a1827a006ad112ea67d36/src/ng/httpBackend.js#L63
