### PR TITLE
Initialise 'on[*]' facade properties to null

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -202,7 +202,7 @@ XHookHttpRequest = window[XMLHTTP] = ->
   hasError = undefined
   transiting = undefined
   response = undefined
-  
+
   #==========================
   # Private API
 

--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -343,6 +343,10 @@ XHookHttpRequest = window[XMLHTTP] = ->
     facade.withCredentials = false
   facade.status = 0
 
+  # initialise all possible event handlers
+  for event in COMMON_EVENTS.concat(UPLOAD_EVENTS)
+    facade["on#{event}"] = null
+
   facade.open = (method, url, async, user, pass) ->
     # Initailize empty XHR facade
     currentState = 0


### PR DESCRIPTION
jQuery 2.2.0 checks for the existence of `onabort` on XMLHttpRequest for backwards compatibility. (https://github.com/jquery/jquery/commit/76e9a95dbeaf28fbc5a64571ebb5959f91a9c14a#diff-d3738ea7b745b19cd90f6d441655df98R120)

Presumably the XHR spec requires these to exist (logically they should anyway). Initialise all seven to `null` on creation.