### PR TITLE
Support zone.js and angular 2

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -306,6 +306,16 @@ XHookHttpRequest = window[XMLHTTP] = ->
   facade = request.xhr = EventEmitter()
 
   #==========================
+  
+  facade.response = xhr.response;
+  facade.responseText = xhr.responseText;
+  facade.responseXML = xhr.responseXML;
+  facade.response = xhr.response;
+  facade.responseURL = xhr.responseURL;
+  facade.readyState = xhr.readyState;
+  facade.status = xhr.status;
+  facade.statusText = xhr.statusText;
+  
   # Handle the underlying ready state
   xhr.onreadystatechange = (event) ->
     #pull status and headers
@@ -475,6 +485,11 @@ XHookHttpRequest = window[XMLHTTP] = ->
 
   return facade
 
+XHookHttpRequest.UNSENT = 0;
+XHookHttpRequest.OPENED = 1;
+XHookHttpRequest.HEADERS_RECEIVED = 2;
+XHookHttpRequest.LOADING = 3;
+XHookHttpRequest.DONE = 4;
 #publicise (amd+commonjs+window)
 if typeof define is "function" and define.amd
   define "xhook", [], -> xhook


### PR DESCRIPTION
Angular 2 use zone.js for async operations, e.g. XMLHttpRequest. Zone.js will wrap all the properties of the XMLHttpRequest object. Properties that are not available on the object when Zone.js wraps the object will not be accessible afterwards. XHooks facade must therefore at creation set the properties that exists on the original XMLHttpRequest object, e.g. .response.
