### PR TITLE
Do not include devDependencies in dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "testcafe": "^0.16.2"
-  },
-  "dependencies": {
+    "testcafe": "^0.16.2",
     "testcafe-browser-provider-saucelabs": "^1.3.0"
   }
 }


### PR DESCRIPTION
When using this package it should not install `testcafe-browser-provider-saucelabs` as it is not a dependency, only a devDependency when working on it locally.