### PR TITLE
Sync fix and module change

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -594,5 +594,7 @@ XHookHttpRequest.DONE = 4;
 #publicise (amd+commonjs+window)
 if typeof define is "function" and define.amd
   define "xhook", [], -> xhook
+else if typeof module is "object" and module.exports
+  module.exports = xhook
 else
-  (@exports or @).xhook = xhook
+  WINDOW.xhook = xhook

--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -285,7 +285,10 @@ XHookHttpRequest = WINDOW[XMLHTTP] = ->
       facade[FIRE] "readystatechange", {}
       #delay final events incase of error
       if currentState is 4
-        setTimeout emitFinal, 0
+        if request.async is false
+          emitFinal()
+        else
+          setTimeout emitFinal, 0
     return
 
   emitFinal = ->


### PR DESCRIPTION
Makes it so setTimeout for emitting the final events only occurs in the async use case.

Also changes the CommonJS case of the export to make it compatible with module bundlers (ie rollup) that expect the module object to be detected and used for exports.

Fixes #81 and #82 

