### PR TITLE
Make `responseType` a proxy property

### DIFF
--- a/src/xhook.coffee
+++ b/src/xhook.coffee
@@ -498,6 +498,13 @@ XHookHttpRequest = WINDOW[XMLHTTP] = ->
     facade.overrideMimeType = ->
       xhr.overrideMimeType.apply xhr, arguments
 
+  #mirror property 'responseType' to native xhr
+  Object.defineProperty facade, 'responseType',
+    get: ->
+      xhr.responseType
+    set: (responseType) ->
+      xhr.responseType = responseType
+
   #create emitter when supported
   if xhr.upload
     facade.upload = request.upload = EventEmitter()


### PR DESCRIPTION
Make `responseType` a proxy property which mimics a native implementation: any attempts to modify `responseType` may fail, and the caller should be able to detect such failures. 

The regarding code is at: https://github.com/mozilla/pdf.js/pull/5531/files
