### PR TITLE
fix: resolve duplex error when fetching with stream body

### DIFF
--- a/src/patch/fetch.ts
+++ b/src/patch/fetch.ts
@@ -124,9 +124,12 @@ const Xhook: typeof fetch = function (input, init = { headers: {} }) {
       }
     };
 
-    const send = () => {
+    const send = async () => {
       const { url, isFetch, acceptedRequest, ...restInit } = options;
-      Native(url, restInit)
+      if (input instanceof Request && restInit.body instanceof ReadableStream) {
+        restInit.body = await new Response(restInit.body).text();
+      }
+      return Native(url, restInit)
         .then(response => processAfter(response))
         .catch(function (err) {
           fullfiled = reject;

--- a/tests/fetch-stream-body.spec.ts
+++ b/tests/fetch-stream-body.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+test("fetch with stream body should not throw errors", async ({ page }) => {
+  await page.goto("http://127.0.0.1:8080/example/common.html");
+  const res = await page.evaluate(async () => {
+    return new Promise(resolve => {
+      const req = new Request("example1.txt", {
+        method: "POST",
+        body: "{}",
+      });
+      fetch(req)
+        .then(res => {
+          resolve(true);
+        })
+        .catch(err => {
+          resolve(false);
+        });
+    });
+  });
+  expect(res).toEqual(true);
+});


### PR DESCRIPTION
Without this patch, `fetch` throws 

```js
TypeError: Failed to execute 'fetch' on 'Window':
 The `duplex` member must be specified for a request with a streaming body
```

when running with a stream body.

```js
fetch(new Request('example1.txt', { method: 'POST' }))  // => ok
fetch(new Request('example1.txt', { method: 'POST', body: '{}' }))  // => exception
```

This patch converts the stream body to plain text before sending it to native fetch.