### PR TITLE
Explicitly set facade.responseType

### DIFF
--- a/src/patch/xmlhttprequest.js
+++ b/src/patch/xmlhttprequest.js
@@ -395,6 +395,7 @@ const Xhook = function () {
   facade.responseXML = null;
   facade.readyState = 0;
   facade.statusText = "";
+  facade.responseType = "";
 
   return facade;
 };


### PR DESCRIPTION
Some clients check to see if `responseType` is present on the xhr before setting it, but then also depend on it being there.

This PR sets a default value on the facade to match what is expected on the xhr. I have verified that at least for the xhr library I'm attempting to shim, it fixes the issue I had encountered.