### PR TITLE
fix: improve event prop merging; add currentTarget

### DIFF
--- a/src/misc/event-emitter.js
+++ b/src/misc/event-emitter.js
@@ -42,6 +42,12 @@ export const EventEmitter = function (nodeStyle) {
         writable: false,
         value: this,
       });
+      if (!args[0].currentTarget) {
+        Object.defineProperty(args[0], "currentTarget", {
+          writable: false,
+          value: this,
+        });
+      }
     }
     const legacylistener = emitter[`on${event}`];
     if (legacylistener) {

--- a/src/misc/events.js
+++ b/src/misc/events.js
@@ -13,7 +13,9 @@ export const mergeObjects = function (src, dst) {
     }
     const v = src[k];
     try {
-      dst[k] = v;
+      if (dst[k] !== v) {
+        Object.defineProperty(dst, k, { value: v });
+      }
     } catch (error) {}
   }
   return dst;

--- a/tests/event-target.spec.ts
+++ b/tests/event-target.spec.ts
@@ -7,7 +7,7 @@ test("event target should be xhr self", async ({ page }) => {
       const xhr = new XMLHttpRequest();
       xhr.open("GET", "example1.txt");
       xhr.addEventListener("load", function (e) {
-        resolve(e.target === xhr);
+        resolve(e.target === xhr && e.currentTarget === xhr);
       });
       xhr.send();
     });


### PR DESCRIPTION
fix #112

### In some events, mergeObjects() fails to copy certain properties

When merging progress and abort events, several errors occur (probably also with error events and timeout events).  
\* Since there is a try-catch, xhook does not stop and no error is output.
```
TypeError: Cannot set property currentTarget of #<Event> which has only a getter
TypeError: Cannot assign to read only property 'CAPTURING_PHASE' of object '#<Event>'
```
This can be fixed by using Object.defineProperty().


### currentTarget is missing in all events

As mentioned above, mergeObjects() fails to copy `currentTarget`.  
In addition, events dispatched by xhook with empty objects do not include `currentTarget`.  
In other words, currentTarget is missing from every event.  
This can be fixed by using Object.defineProperty() for events where `currentTarget` is null.

\* I intentionally left out  [`srcElement`](https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement) because it’s a deprecated alias for `target`.